### PR TITLE
Add README and document bot deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# Telegram Marketplace Bot
+
+This project contains a small web interface built with React and a simple
+Telegram bot implemented in `api/bot.py`.
+
+## Installation
+
+### Node dependencies
+
+```bash
+npm install
+```
+
+### Python dependencies
+
+`api/bot.py` relies only on Python's standard library (`json`, `os`,
+`urllib` and `http.server`).  No additional packages are required.  If you
+extend the bot to use third-party libraries, list them in
+`requirements.txt` and install with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running locally
+
+The React app can be started with:
+
+```bash
+npm start
+```
+
+The bot handler is designed for serverless environments that pass incoming
+Telegram webhook requests to `api/bot.py`.

--- a/api/bot.py
+++ b/api/bot.py
@@ -1,3 +1,10 @@
+"""Telegram marketplace bot webhook handler.
+
+This script relies solely on Python's standard library modules
+(``json``, ``os``, ``urllib`` and ``http.server``).  No third-party
+packages are required.
+"""
+
 import json
 import os
 import urllib.request


### PR DESCRIPTION
## Summary
- document that `api/bot.py` only uses Python's built-in modules
- add installation instructions

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68655d5e62388326b2a78972e5fdc815