### PR TITLE
Add unit tests for wallet and React component

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Telegram Marketplace Bot
+
+## Running Tests
+
+JavaScript/TypeScript tests:
+
+```bash
+npm test -- --watchAll=false
+```
+
+Python tests:
+
+```bash
+npm run test:py
+```
+
+Lint all code:
+
+```bash
+npm run lint
+```

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "start": "react-scripts start",
     "build": "cross-env NODE_OPTIONS=--openssl-legacy-provider react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "test:py": "PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest",
+    "lint": "eslint . --ext .ts,.tsx,.js"
   },
   "dependencies": {
     "core-js": "^3.43.0",
@@ -20,7 +22,9 @@
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "cross-env": "^7.0.3",
-    "typescript": "^4.2.4"
+    "typescript": "^4.2.4",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.0.0"
   },
   "eslintConfig": {
     "extends": [

--- a/src/__tests__/WalletConnect.test.tsx
+++ b/src/__tests__/WalletConnect.test.tsx
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import WalletConnect from '../components/WalletConnect';
+
+test('renders connect button', () => {
+  render(<WalletConnect />);
+  expect(screen.getByRole('button', { name: '지갑 연결' })).toBeInTheDocument();
+});

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -1,0 +1,14 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from api import crypto_wallet
+
+
+def test_create_wallet():
+    wallet = crypto_wallet.create_wallet()
+    assert "address" in wallet and "private_key" in wallet
+    assert wallet["address"].startswith("0x")
+    # private keys returned by eth_account do not include a 0x prefix
+    assert len(wallet["private_key"]) >= 64


### PR DESCRIPTION
## Summary
- add `tests/` directory with wallet test
- add React component test
- document how to run tests
- expose lint and pytest commands in `package.json`

## Testing
- `npm run test:py`
- `CI=true npm test -- --watchAll=false`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6866a6a9383c8326916440a4e5cd9919